### PR TITLE
using updated app configuration style

### DIFF
--- a/src/fb_github/__init__.py
+++ b/src/fb_github/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'fb_github.apps.FbGithubConfig'

--- a/src/firebot/settings/base.py
+++ b/src/firebot/settings/base.py
@@ -24,9 +24,9 @@ INSTALLED_APPS = (
     'django_extensions',
     'rest_framework',
 
-    'firebot',
-    'fb_emails',
-    'fb_github',
+    'firebot.apps.FireBotConfig',
+    'fb_emails.apps.FbEmailsConfig',
+    'fb_github.apps.FbGithubConfig',
 )
 
 MIDDLEWARE = [


### PR DESCRIPTION
Dropping `default_app_config` in favor of the "recommended" way of doing things:
> New applications should avoid default_app_config. Instead they should require the dotted path to the appropriate AppConfig subclass to be configured explicitly in INSTALLED_APPS.
https://docs.djangoproject.com/en/1.11/ref/applications/